### PR TITLE
Fetch profile picture URL without HTTP 302 redirect

### DIFF
--- a/src/Kdyby/Facebook/Profile.php
+++ b/src/Kdyby/Facebook/Profile.php
@@ -110,7 +110,7 @@ class Profile extends Nette\Object
 	public function getPictureUrl()
 	{
 		try {
-			return $this->facebook->api('/' . $this->profileId . '/picture')->url;
+			return $this->facebook->api('/' . $this->profileId . '/picture', NULL, array('redirect' => FALSE,))->data->url;
 
 		} catch (FacebookApiException $e) {
 			return NULL;


### PR DESCRIPTION
Default behavior in API use HTTP code 302 to redirect to data which contains URL for profile picture. It does not work with some older version of PHP (5.3.*).
This update works in PHP 5.3 and PHP 5.4 and does not contain any redirect so it could be faster :-)
