### PR TITLE
Option to not provide appsecret_proof in API request

### DIFF
--- a/src/Kdyby/Facebook/Api/CurlClient.php
+++ b/src/Kdyby/Facebook/Api/CurlClient.php
@@ -189,11 +189,11 @@ class CurlClient extends Nette\Object implements Facebook\ApiClient
 			$params['access_token'] = $this->fb->getAccessToken();
 		}
 
-		if (isset($params['access_token']) && !isset($params['appsecret_proof'])) {
+		if ($this->fb->getConfig()->verifyApiCalls && isset($params['access_token']) && !isset($params['appsecret_proof'])) {
 			$params['appsecret_proof'] = $this->fb->config->getAppSecretProof($params['access_token']);
 		}
 
-		if($params['appsecret_proof'] === false) {
+		if ($params['appsecret_proof'] === false) {
 			unset($params['appsecret_proof']);
 		}
 

--- a/src/Kdyby/Facebook/Configuration.php
+++ b/src/Kdyby/Facebook/Configuration.php
@@ -113,6 +113,12 @@ class Configuration extends Nette\Object
 	public $appSecret;
 
 	/**
+	 * Verify API calls by adding appsecret_proof to all calls
+	 * @var string
+	 */
+	public $verifyApiCalls;
+
+	/**
 	 * Indicates if the CURL based @ syntax for file uploads is enabled.
 	 * @var boolean
 	 */

--- a/src/Kdyby/Facebook/DI/FacebookExtension.php
+++ b/src/Kdyby/Facebook/DI/FacebookExtension.php
@@ -28,6 +28,7 @@ class FacebookExtension extends Nette\DI\CompilerExtension
 	public $defaults = array(
 		'appId' => NULL,
 		'appSecret' => NULL,
+		'verifyApiCalls' => TRUE,
 		'fileUploadSupport' => FALSE,
 		'trustForwarded' => FALSE,
 		'clearAllWithLogout' => TRUE,
@@ -65,6 +66,7 @@ class FacebookExtension extends Nette\DI\CompilerExtension
 		$configurator = $builder->addDefinition($this->prefix('config'))
 			->setClass('Kdyby\Facebook\Configuration')
 			->setArguments(array($config['appId'], $config['appSecret']))
+			->addSetup('$verifyApiCalls', array($config['verifyApiCalls']))
 			->addSetup('$fileUploadSupport', array($config['fileUploadSupport']))
 			->addSetup('$trustForwarded', array($config['trustForwarded']))
 			->addSetup('$permissions', array($config['permissions']))


### PR DESCRIPTION
There are use cases when we do not want to provide appsecret_proof in request at all.

One example is validation of access_token generated by different application.

Validation is possible by checking access token owner:
https://graph.facebook.com/me?access_token=CAAHT1drGwlkBANZCnXNXTFzEvyVGKU89z0n0PMrnZCZCZB2VYL3YgTqhcwrSPGCCXDBZBKEfeDvrkJBgnkJhFo87IWFwTZAXU2SJ6GerYg4JnHgLt3NzqhFvNaFmBa7xzcf124UcZAFBJ0mEOef1ZAZAb7z8vJLLU2tyFL5DCOkciZCXLXWemU3awjJNZB8GaLq81MtpB50ilXJxIs9x4xlUQFQ

But when appsecret_proof is provided it ends by error "Invalid appsecret_proof provided in the API argument" if original token is generated by different app.

We use this to prove user is logged in mobile app when accessing our application API. User lg in in mobile app. Mobile app recevives own access token. When authentication with our API, mobile app just send us access token, which we validates.

Usage then looks like this:

```
$facebook->api('/me', NULL, array("appsecret_proof" => false));
```
