### PR TITLE
ResourceLoader - Fixed handling with access tokens and limits

### DIFF
--- a/src/Kdyby/Facebook/Facebook.php
+++ b/src/Kdyby/Facebook/Facebook.php
@@ -189,7 +189,7 @@ class Facebook extends Nette\Object
 	 */
 	public function iterate($pathOrParams, $method = NULL, array $params = array())
 	{
-		return new Resource\ResourceLoader($this, $pathOrParams, $method, $params);
+		return new Resource\ResourceLoader($this, $pathOrParams, $method, $params, $this->getAccessToken());
 	}
 
 


### PR DESCRIPTION
1. Solves problem with accessToken used in Facebook object called by ResourceLoader. 
2. Checking total count limit 
