### PR TITLE
Facebook: added checkPermissions method

### DIFF
--- a/src/Kdyby/Facebook/Facebook.php
+++ b/src/Kdyby/Facebook/Facebook.php
@@ -647,4 +647,31 @@ class Facebook extends Nette\Object
 		return $default;
 	}
 
+    /**
+     * Check if needed permissions is still actual
+     *
+     * @throws \Kdyby\Facebook\FacebookApiException
+     * @return bool
+     */
+    public function checkPermissions(){
+        if (empty($this->config->permissions)) return true; // We needed nothing...
+        // Load actual permissions
+        $loadedPermissions = $this->api("/me/permissions");
+        // No valid response
+        if (!is_array($loadedPermissions) || !isset($loadedPermissions["data"]) || !is_array($loadedPermissions["data"]))
+            return false;
+        $loaded = array();
+        // Iterate over loaded perms. and store it to simple array
+        foreach($loadedPermissions["data"] as $fbPermission){
+            if ($fbPermission["status"] == "granted")
+                $loaded[] = $fbPermission["permission"];
+        }
+        // Iterate over configured perms. and check if is in array with loaded perms.
+        foreach($this->config->permissions as $permission){
+            if (!in_array($permission, $loaded)) return false; // this perm is not in loaded perms.
+        }
+        // All is OK
+        return true;
+    }
+
 }


### PR DESCRIPTION
This method re-checks needed permissions based on configuration.

Basic example:
```php
if (!$this->fb->checkPermissions()){
   $dialog = $this->fb->createDialog("login");
   $loginUrl = $dialog->getUrl(
      $dialog::DISPLAY_PAGE // Or what do you need...
   );
   $this->redirectUrl($loginUrl."&auth_type=rerequest"); // TODO: Add "re-request" type as param
}
```