### PR TITLE
getPermissions() works with API v2.x. Output is v1.0 compatible.

### DIFF
--- a/src/Kdyby/Facebook/Profile.php
+++ b/src/Kdyby/Facebook/Profile.php
@@ -133,8 +133,14 @@ class Profile extends Nette\Object
 
 		try {
 			$response = $this->facebook->api("/{$this->profileId}/permissions", 'GET', $params);
-			if ($response && !empty($response->data[0])) {
-				return ArrayHash::from($response->data[0]);
+			if ($response && !empty($response->data)) {
+				$items = array();
+				foreach ($response->data as $permissionsItem) {
+					if ($permissionsItem->status === 'granted') {
+						$items[$permissionsItem->permission] = 1;
+					}
+				}
+				return ArrayHash::from($items);
 			}
 
 		} catch (FacebookApiException $e) {


### PR DESCRIPTION
[Closes #29]