### PR TITLE
Oprava monitoringu při použití v subkomponentách

### DIFF
--- a/src/Kdyby/Facebook/Dialog/AbstractDialog.php
+++ b/src/Kdyby/Facebook/Dialog/AbstractDialog.php
@@ -69,7 +69,7 @@ abstract class AbstractDialog extends PresenterComponent implements Facebook\Dia
 		$this->config = $facebook->config;
 		$this->currentUrl = $facebook->getCurrentUrl();
 
-		$this->monitor('Nette\Application\IPresenter');
+		$this->monitor('Nette\Application\UI\Presenter');
 		parent::__construct();
 	}
 
@@ -92,7 +92,7 @@ abstract class AbstractDialog extends PresenterComponent implements Facebook\Dia
 	{
 		parent::attached($obj);
 
-		if ($obj instanceof Nette\Application\IPresenter) {
+		if ($obj instanceof Nette\Application\UI\Presenter) {
 			$this->currentUrl = new UrlScript($this->link('//response!'));
 		}
 	}


### PR DESCRIPTION
Mám komponentu (na přihlašování), která obsahuje další komponentu na přihlašování přes fb (kdyby/facebook). Pokud se přihlašuju poprvé je vše v pořádku.
V případě, že mi uživatel odmítne nějaké právo, které potřebuju, tak potřebuju požádat o práva znovu s parametrem auth_type=rerequest.
Odkaz na tuhle akci vytvářím `<a n:href="fbLogin-open!, fbLogin-authType => 'rerequest'">` Odkaz se vygeneruje správně, ale když na něj kliknu, tak v handlu nemám předanou hodnotu parametru auth_type.

Krokováním jsem zjistil, že `attached()` na `AbstractDialog` se zavolá dvakrát a při druhém volání je `$this->getParameters()` už jen prázdné pole.

Jak se ukázalo, tak za problémem bylo "dvojí" monitorování presenteru přes třídu i rozhraní. Nahradil jsem tedy monitoring `Nette\Application\IPresenter` za `Nette\Application\UI\Presenter` stejně jako je to v `PresenterComponent`.
