### PR TITLE
Fixed notice in CurlClient when no appsecret_proof provided

### DIFF
--- a/src/Kdyby/Facebook/Api/CurlClient.php
+++ b/src/Kdyby/Facebook/Api/CurlClient.php
@@ -214,7 +214,7 @@ class CurlClient extends Nette\Object implements Facebook\ApiClient
 			$params['appsecret_proof'] = $this->fb->config->getAppSecretProof($params['access_token']);
 		}
 
-		if ($params['appsecret_proof'] === false) {
+		if (isset($params['appsecret_proof']) && $params['appsecret_proof'] === false) {
 			unset($params['appsecret_proof']);
 		}
 


### PR DESCRIPTION
[Closes #36]