### PR TITLE
Fixed setExtendedAccessToken - FB API returns JSON and not a parse_str compatible string

### DIFF
--- a/src/Kdyby/Facebook/Facebook.php
+++ b/src/Kdyby/Facebook/Facebook.php
@@ -13,6 +13,7 @@ namespace Kdyby\Facebook;
 use Kdyby\Facebook\Api\CurlClient;
 use Nette;
 use Nette\Utils\ArrayHash;
+use Nette\Utils\Json;
 
 
 
@@ -267,7 +268,7 @@ class Facebook extends Nette\Object
 				return FALSE;
 			}
 
-			parse_str($response, $params);
+			$params = Json::decode($response, Json::FORCE_ARRAY);
 			if (!isset($params['access_token'])) {
 				return FALSE;
 			}


### PR DESCRIPTION
Not sure if it depends on FB API version or something, but this method did not work in our app until I fixed it to decode JSON.