### PR TITLE
Nette 2.4 compatibility fix

### DIFF
--- a/src/Kdyby/Facebook/Diagnostics/Panel.php
+++ b/src/Kdyby/Facebook/Diagnostics/Panel.php
@@ -52,7 +52,7 @@ class Panel extends Nette\Object implements IBarPanel
 	public function getTab()
 	{
 		$logo = Html::el()->setHtml(file_get_contents(__DIR__ . '/logo.svg'));
-		$tab = Html::el()->add($logo);
+		$tab = Html::el()->addHtml($logo);
 		$title = Html::el('span', ['class' => 'tracy-label'])->title('Facebook');
 
 		if ($this->calls) {
@@ -65,7 +65,7 @@ class Panel extends Nette\Object implements IBarPanel
 			$title->setText('Facebook');
 		}
 
-		return (string)$tab->add($title);
+		return (string)$tab->addHtml($title);
 	}
 
 


### PR DESCRIPTION
Changed deprecated `add()` to `addHtml()`. Tracy debug bar is now working without error after updating Nette Utils to 2.4.

**This fix is not compatible with Nette Utils 2.3 and lower.** Branch for Nette 2.3 should be created.

![facebook-panel](https://cloud.githubusercontent.com/assets/20677808/17168082/a6874cc8-53e0-11e6-982e-bd1d3689002f.png)
