### PR TITLE
Nette 2.2 is not supported from May 2016

### DIFF
--- a/tests/KdybyTests/Facebook/Extension.phpt
+++ b/tests/KdybyTests/Facebook/Extension.phpt
@@ -34,7 +34,7 @@ class ExtensionTest extends Tester\TestCase
 		$config = new Nette\Configurator();
 		$config->setTempDirectory(TEMP_DIR);
 		Kdyby\Facebook\DI\FacebookExtension::register($config);
-		$config->addConfig(__DIR__ . '/files/config.neon', $config::NONE);
+		$config->addConfig(__DIR__ . '/files/config.neon');
 
 		return $config->createContainer();
 	}

--- a/tests/KdybyTests/Facebook/FacebookTestCase.php
+++ b/tests/KdybyTests/Facebook/FacebookTestCase.php
@@ -68,8 +68,8 @@ abstract class FacebookTestCase extends Tester\TestCase
 		$config = new Nette\Configurator();
 		$config->setTempDirectory(TEMP_DIR);
 		Kdyby\Facebook\DI\FacebookExtension::register($config);
-		$config->addConfig(__DIR__ . '/files/' . $fbConfig, $config::NONE);
-		$config->addConfig(__DIR__ . '/../nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22');
+		$config->addConfig(__DIR__ . '/files/' . $fbConfig);
+		$config->addConfig(__DIR__ . '/../nette-reset.neon');
 
 		/** @var \Nette\DI\Container|\SystemContainer $dic */
 		$dic = $config->createContainer();

--- a/tests/KdybyTests/nette-reset.neon
+++ b/tests/KdybyTests/nette-reset.neon
@@ -1,28 +1,18 @@
-common:
-	php:
-		date.timezone: Europe/Prague
+php:
+	date.timezone: Europe/Prague
 
-	extensions:
-		fakeSession: Kdyby\FakeSession\DI\FakeSessionExtension
+extensions:
+	fakeSession: Kdyby\FakeSession\DI\FakeSessionExtension
 
-	fakeSession:
-		enabled: yes
+fakeSession:
+	enabled: yes
 
-	services:
-		cacheStorage:
-			class: Nette\Caching\Storages\MemoryStorage
+http:
+	frames: null
 
-v22 < common:
-	nette:
-		security:
-			frames: null
+services:
+	cacheStorage:
+		class: Nette\Caching\Storages\MemoryStorage
 
-		session:
-			autoStart: false
-
-v23 < common:
-	http:
-		frames: null
-
-	session:
-		autoStart: false
+session:
+	autoStart: false

--- a/tests/delete-used-test-accounts.php
+++ b/tests/delete-used-test-accounts.php
@@ -15,8 +15,8 @@ require_once __DIR__ . '/../vendor/autoload.php';
 $config = new Nette\Configurator();
 $config->setTempDirectory(__DIR__ . '/tmp');
 Kdyby\Facebook\DI\FacebookExtension::register($config);
-$config->addConfig(__DIR__ . '/KdybyTests/Facebook/files/config.kdyby.neon', $config::NONE);
-$config->addConfig(__DIR__ . '/KdybyTests/nette-reset.neon', !isset($config->defaultExtensions['nette']) ? 'v23' : 'v22');
+$config->addConfig(__DIR__ . '/KdybyTests/Facebook/files/config.kdyby.neon');
+$config->addConfig(__DIR__ . '/KdybyTests/nette-reset.neon');
 
 /** @var \Nette\DI\Container $container */
 $container = $config->createContainer();


### PR DESCRIPTION
Drop BC for Nette 2.2 and make tests green again with nette 2.4.
