### PR TITLE
Dialog should respect dropQueryParams configuration too.

### DIFF
--- a/src/Kdyby/Facebook/Dialog/AbstractDialog.php
+++ b/src/Kdyby/Facebook/Dialog/AbstractDialog.php
@@ -93,6 +93,10 @@ abstract class AbstractDialog extends PresenterComponent implements Facebook\Dia
 
 		if ($obj instanceof Nette\Application\UI\Presenter) {
 			$this->currentUrl = new UrlScript($this->link('//response!'));
+
+			parse_str($this->currentUrl->getQuery(), $query);
+			$query = array_diff_key($query, array_flip($this->config->dropQueryParams));
+			$this->currentUrl->setQuery($query);
 		}
 	}
 


### PR DESCRIPTION
As Facebook now forces all new applications to use _Strict Mode for Redirect URIs_ when using Facebook Login it would be handy if `LoginDialog` respect configuration option `dropQueryParams` as `Facebook::getCurrentUrl()` currently does.

It would allow to remove temporary GET parameters like `backlink` and it would make redirect workflow easier :-)